### PR TITLE
removed window_size and desktop_window

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,16 +7,12 @@ import Foundation
 
 import dart_wormhole_william
 import desktop_drop
-import desktop_window
 import path_provider_macos
 import shared_preferences_macos
-import window_size
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DartWormholeWilliamPlugin.register(with: registry.registrar(forPlugin: "DartWormholeWilliamPlugin"))
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
-  DesktopWindowPlugin.register(with: registry.registrar(forPlugin: "DesktopWindowPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  WindowSizePlugin.register(with: registry.registrar(forPlugin: "WindowSizePlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,26 +1,38 @@
 PODS:
+  - dart_wormhole_william (0.0.1):
+    - FlutterMacOS
   - desktop_drop (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - path_provider_macos (0.0.1):
+    - FlutterMacOS
   - shared_preferences_macos (0.0.1):
     - FlutterMacOS
 
 DEPENDENCIES:
+  - dart_wormhole_william (from `Flutter/ephemeral/.symlinks/plugins/dart_wormhole_william/macos`)
   - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - path_provider_macos (from `Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos`)
   - shared_preferences_macos (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos`)
 
 EXTERNAL SOURCES:
+  dart_wormhole_william:
+    :path: Flutter/ephemeral/.symlinks/plugins/dart_wormhole_william/macos
   desktop_drop:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  path_provider_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_macos/macos
   shared_preferences_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_macos/macos
 
 SPEC CHECKSUMS:
+  dart_wormhole_william: 0d331b013205c67f8e452d1c84818aeff7daf459
   desktop_drop: 69eeff437544aa619c8db7f4481b3a65f7696898
   FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  path_provider_macos: 160cab0d5461f0c0e02995469a98f24bdb9a3f1f
   shared_preferences_macos: 480ce071d0666e37cef23fe6c702293a3d21799e
 
 PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -27,10 +27,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "023e1f86bba7ebfcabfa4ed77ce01a5af358ea04"
+      resolved-ref: "49724e6c310d061ae5d1b50d3eada3e5412eba20"
       url: "https://github.com/Ephenodrom/Dart-Basic-Utils"
     source: git
-    version: "3.9.1"
+    version: "3.9.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -101,13 +101,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
-  desktop_window:
-    dependency: "direct main"
-    description:
-      name: desktop_window
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.0"
   dotted_border:
     dependency: "direct main"
     description:
@@ -142,7 +135,7 @@ packages:
       name: file_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.7"
+    version: "4.3.0"
   filepicker_windows:
     dependency: "direct main"
     description:
@@ -173,7 +166,7 @@ packages:
       name: flutter_screenutil
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.1+3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -286,14 +279,14 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.11"
   path_provider_ios:
     dependency: transitive
     description:
@@ -307,7 +300,7 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   path_provider_macos:
     dependency: transitive
     description:
@@ -363,7 +356,7 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.11"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -501,16 +494,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
-  window_size:
-    dependency: "direct main"
-    description:
-      path: "plugins/window_size"
-      ref: HEAD
-      resolved-ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
-      url: "git://github.com/google/flutter-desktop-embedding.git"
-    source: git
-    version: "0.1.0"
+    version: "2.3.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,10 +32,6 @@ dependencies:
   intro_slider:
     git:
       url: https://github.com/shareef-dweikat/flutter-intro-slider
-  window_size:
-    git:
-      url: git://github.com/google/flutter-desktop-embedding.git
-      path: plugins/window_size
   flutter:
     sdk: flutter
 
@@ -43,7 +39,6 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   app_settings: ^4.1.1
-  desktop_window: ^0.4.0
   filepicker_windows: ^2.0.0
   page_transition: ^2.0.4
   path_provider: ^2.0.0


### PR DESCRIPTION
---
I used window_size and desktop_window dependencies to resize mobile UI to fit desktop. Now we have a separate UI for desktop, so we don't need the mentioned dependencies anymore.
## Code Review Checklist

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
