### PR TITLE
Remove open_file lib

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -380,13 +380,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  open_file:
-    dependency: "direct main"
-    description:
-      name: open_file
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.2.1"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,7 +52,6 @@ dependencies:
   dotted_border: ^2.0.0+1
   desktop_drop: ^0.3.0
   permission_handler: ^9.2.0
-  open_file: ^3.2.1
   flutter_spinkit: ^5.1.0
   device_info_plus: ^3.2.3
   provider: ^6.0.0


### PR DESCRIPTION
---
OP#1902
open_file lib is not used in the project and it is asking for android.permission.REQUEST_INSTALL_PACKAGES permission. This one is not allowed anymore in google play. If we need it, we need to give a good reason to google to keep it.
## Code Review Checklist

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
