### PR TITLE
Update appId to match Magic-Wormhole protocol appId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .history
 .svn/
 *.jks
+.vscode/
 
 # IntelliJ related
 *.iml

--- a/lib/constants/app_constants.dart
+++ b/lib/constants/app_constants.dart
@@ -171,7 +171,7 @@ final Config magicWormholeIO = Config(
 final Config leastAuthority = Config(
   rendezvousUrl: "wss://mailbox.w.leastauthority.com/v1",
   transitRelayUrl: "tcp:relay.w.leastauthority.com:4001",
-  appId: "myFileTransfer",
+  appId: "lothar.com/wormhole/text-or-file-xfer",
 );
 
 final Config local = Config(


### PR DESCRIPTION
Changing Least Authority appID: myFileTransfer to Magic-Wormhole ecosystem common appId: lothar.com/wormhole/text-or-file-xfer to make closer interoperability with the rest of MW implementations. 

---

## Code Review Checklist

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
