### PR TITLE
Change default windows size

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,9 +19,9 @@ void startApp(Config c) {
   SystemChrome.setPreferredOrientations(
       [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
   if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
-    setWindowMinSize(const Size(700, 700));
+    setWindowMinSize(const Size(900, 800));
     setWindowMaxSize(const Size(1600, 1200));
-    setWindowFrame(Rect.fromLTWH(0, 0, 700, 700));
+    setWindowFrame(Rect.fromLTWH(0, 0, 900, 800));
   }
   runApp(MultiProvider(providers: [
     ChangeNotifierProvider(create: (context) => SendSharedState(c)),


### PR DESCRIPTION
Change default windows size from 700x700 for desktop to 900x800 to have better support for increased font sizes.
At least this helps to look better on Windows with 125% scaling

---

## Code Review Checklist

- [ ] Description accurately reflects what changes are being made.
- [ ] Description explains why the changes are being made (or references an issue containing one).
- [ ] The PR appropriately sized.
- [ ] New code has enough tests. 
- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".
- [ ] Existing documentation is up-to-date, if impacted.
